### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.DataProviders.nuspec
+++ b/MakoIoT.Device.Services.DataProviders.nuspec
@@ -18,9 +18,9 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot data providers</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
-      <dependency id="nanoFramework.Logging" version="1.1.63" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
+      <dependency id="nanoFramework.Logging" version="1.1.74" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.39.3768" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.DataProviders/MakoIoT.Device.Services.DataProviders.nfproj
+++ b/src/MakoIoT.Device.Services.DataProviders/MakoIoT.Device.Services.DataProviders.nfproj
@@ -25,22 +25,20 @@
     <Compile Include="Extensions\DeviceBuilderExtension.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.39.3768\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>
-    </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.74.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.74\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.DataProviders/packages.config
+++ b/src/MakoIoT.Device.Services.DataProviders/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.39.3768" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.74" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.38.18612 to 1.0.39.3768</br>Bumps nanoFramework.DependencyInjection from 1.1.1 to 1.1.3</br>Bumps nanoFramework.Logging from 1.1.63 to 1.1.74</br>
[version update]

### :warning: This is an automated update. :warning:
