### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.DataProviders.nuspec
+++ b/MakoIoT.Device.Services.DataProviders.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot data providers</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
     </dependencies>
   </metadata>

--- a/src/MakoIoT.Device.Services.DataProviders/MakoIoT.Device.Services.DataProviders.nfproj
+++ b/src/MakoIoT.Device.Services.DataProviders/MakoIoT.Device.Services.DataProviders.nfproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.53.21413\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.DataProviders/packages.config
+++ b/src/MakoIoT.Device.Services.DataProviders/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnanoframework10" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.53.21413 to 1.0.54.39044</br>
[version update]

### :warning: This is an automated update. :warning:
